### PR TITLE
Update wsgi file to use whitenoise.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ CMD ["./bin/run-docker.sh"]
 RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home webdev
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential python-dev libpq-dev gettext libjpeg62-turbo-dev postgresql-client sharutils libjpeg62-turbo gunicorn
+    apt-get install -y --no-install-recommends build-essential python-dev libpq-dev gettext libjpeg62-turbo-dev postgresql-client sharutils libjpeg62-turbo
 
 # Pin a known to work with peep pip version.
 RUN pip install --no-cache-dir pip==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,9 @@ tablib==0.10.0
 diff-match-patch==20121119
 # sha256: as-au751fvddwuzZ2RunSVR5Qauv--af8ghqnjfUkEw
 psycopg2==2.6.1
+# sha256: GclSD80sHoOWHNx92wsN63uToa6nn1buDWxeJAP8qk0
+# sha256: wLZGoH80oy6PZjJqgZzu8PvBwjNW3IRFFgvHaGGw30w
+whitenoise==2.0.3
+# sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY
+# sha256: i8g1CCiCrZoBLNeQxGABHk2WvzUS2YoE09q75FOToIk
+gunicorn==19.3.0

--- a/woodstock/wsgi.py
+++ b/woodstock/wsgi.py
@@ -1,32 +1,19 @@
 """
-WSGI config for woodstock project.
+WSGI config for woodstock app.
 
-This module contains the WSGI application used by Django's development server
-and any production WSGI deployments. It should expose a module-level variable
-named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
-this application via the ``WSGI_APPLICATION`` setting.
-
-Usually you will have the standard Django WSGI application here, but it also
-might make sense to replace the whole Django WSGI application with a custom one
-that later delegates to the Django one. For example, you could introduce WSGI
-middleware here, or combine a Django application with an application of another
-framework.
-
+It exposes the WSGI callable as a module-level variable named ``application``.
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 import os
 
-# We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
-# if running multiple sites in the same mod_wsgi process. To fix this, use
-# mod_wsgi daemon mode with each site in its own daemon process, or use
-# os.environ["DJANGO_SETTINGS_MODULE"] = "woodstock.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "woodstock.settings")
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+from whitenoise.django import DjangoWhiteNoise
 
-# Apply WSGI middleware here.
-# from helloworld.wsgi import HelloWorldApplication
-# application = HelloWorldApplication(application)
+application = get_wsgi_application()
+application = DjangoWhiteNoise(application)


### PR DESCRIPTION
- Install gunicorn from pypi instead.
- Fixes issue when running gunicorn in our docker image
